### PR TITLE
Restricts build description to be no more than 100 characters

### DIFF
--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -28,6 +28,18 @@ module DPL
         update_app(version)
       end
 
+      def commit_msg
+        # elastic beanstalk has a limitation for build
+        # descriptions to be no more than 100 characters in length
+        msg = super
+        
+        if msg.length > 100
+          msg[0, 99] + '…'
+        else
+          msg
+        end
+      end
+
       private
 
       def app_name


### PR DESCRIPTION
Elastic Beanstalk has a limitation for build description to be no more than
100 characters. If a build is submitted with more than then limitation, the
build request fails.

Since we are pulling the build description from the commit message, this limits
the commit message to be always within 100 characters. This makes restricts
the amount of useful information that we can place into the commit message.
